### PR TITLE
Added navigation to the previous link with shift+tab

### DIFF
--- a/Sources/Input.c
+++ b/Sources/Input.c
@@ -30,7 +30,7 @@ void Prompt( char *str )
 		/* Fucking printf doesn't cut string if larger than * */
 		if( plen > terminfo.width-7 )
 			memcpy(svg, str + (plen = terminfo.width - 8), 2),
-			memcpy(str + plen, "�", 2);
+			memcpy(str + plen, "»", 2);
 
 		printf("[%d;H[0;7m%4d%%%*s[0m[%d;6H",
 				terminfo.height,(node && node->maxlines > terminfo.height ?
@@ -171,12 +171,12 @@ void ProcessKeys( void )
         "[Z", /* backtab */
         NULL
 	};
-    static char* StrNode[] = {
-        "help", "index", "table of content"
-    };
-    extern struct scrpos terminfo;
-    static char buffer[10], *p;
-
+	static char *StrNode[] = {
+		"help", "index", "table of content"
+	};
+	extern struct scrpos terminfo;
+	static char buffer[10], *p;
+	
 	/* Display node's name in status bar */
 	Prompt(AGNODE(&terminfo)->title);
 	for(p=buffer; ; ) {

--- a/Sources/Input.c
+++ b/Sources/Input.c
@@ -30,7 +30,7 @@ void Prompt( char *str )
 		/* Fucking printf doesn't cut string if larger than * */
 		if( plen > terminfo.width-7 )
 			memcpy(svg, str + (plen = terminfo.width - 8), 2),
-			memcpy(str + plen, "»", 2);
+			memcpy(str + plen, "ï¿½", 2);
 
 		printf("[%d;H[0;7m%4d%%%*s[0m[%d;6H",
 				terminfo.height,(node && node->maxlines > terminfo.height ?
@@ -161,19 +161,21 @@ void ChangeTabstop(AGNode node, short step)
 /*** Process key-in commands ***/
 void ProcessKeys( void )
 {
-	static char *Keys[] = {
-		"OA", "OB", "OC","OD",        /* Cursor keys */
-		"[5~","[6~","[H","[F",        /* PgDown, PgUp, End, Home */
-		"[1~","[4~","OH","OF",        /* 2x Alternative End, Home */
-		"[11~","[12~", "[13~",        /* F1, F2, F3 */
-		"OP" ,"OQ", "OR",             /* Alternative F1, F2, F3 */
-		"[[A","[[B","[[C", NULL       /* Linux console F1, F2, F3 */
+    static char* Keys[] = {
+        "OA", "OB", "OC", "OD", /* Cursor keys */
+        "[5~", "[6~", "[H", "[F", /* PgDown, PgUp, End, Home */
+        "[1~", "[4~", "OH", "OF", /* 2x Alternative End, Home */
+        "[11~", "[12~", "[13~", /* F1, F2, F3 */
+        "OP", "OQ", "OR", /* Alternative F1, F2, F3 */
+        "[[A", "[[B", "[[C", /* Linux console F1, F2, F3 */
+        "[Z", /* backtab */
+        NULL
 	};
-	static char *StrNode[] = {
-		"help", "index", "table of content"
-	};
-	extern struct scrpos terminfo;
-	static char buffer[10], *p;
+    static char* StrNode[] = {
+        "help", "index", "table of content"
+    };
+    extern struct scrpos terminfo;
+    static char buffer[10], *p;
 
 	/* Display node's name in status bar */
 	Prompt(AGNODE(&terminfo)->title);
@@ -221,7 +223,9 @@ void ProcessKeys( void )
 						case 18: p[-1] = '1'; goto singleton;
 						case 19: p[-1] = '2'; goto singleton;
 						case 20: p[-1] = '3'; goto singleton;
-					}
+                        /* backtab */ 
+                        case 21: FindNextLink(&terminfo, -1); goto singleton;
+                                        }
 					p=buffer;
 				} else goto singleton;
 			} else goto singleton;


### PR DESCRIPTION
You could already press "p" to highlight the previous link, but I find shift+tab more intuitive.
It's possible that the original author didn't include it because back then many terminal emulators didn't send the relevant escape sequence.
